### PR TITLE
Two small fixes

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -16,12 +16,12 @@ ipc.on('show-preferences', () => {
 
 ipc.on('new-email', () => {
     // Click COMPOSE button
-    document.querySelector('.compose.pm_button.primary').click();
+    document.querySelector('.sidebar-btn-compose').click();
 });
 
 ipc.on('log-out', () => {
     // Click hided logout button
-    document.querySelector('.pm_button.primary.text-center').click();
+    document.querySelector('.navigationUser-logout').click();
 });
 
 ipc.on('close-composer', () => {

--- a/src/menu.js
+++ b/src/menu.js
@@ -155,6 +155,12 @@ const MenuTpl = [{
     label: 'View',
     submenu: viewSubmenu
 }, {
+    role: 'window',
+    submenu: [
+      {role: 'minimize'},
+      {role: 'close'}
+    ]
+}, {
     label: 'Help',
     role: 'help',
     submenu: helpSubmenu


### PR DESCRIPTION
Hey, 

Thank you for the very useful tool :-)

Protonmail changed the css class names for the "compose" and "logout" button. I've updated the selectors.  Also, i've enabled the "window" menu to allow os x users to close the window via keyboard shortcut.

Best Regards,
Michael